### PR TITLE
Update StructChunked API calls for Polars 0.53.0 compatibility

### DIFF
--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         target: [x86_64]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         target: [x86_64]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -31,8 +31,8 @@ jobs:
         target: [x86_64]
         python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -67,23 +67,23 @@ jobs:
       matrix:
         target: [x86_64, x86]
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
-          
+
           target: ${{ matrix.target }}
-          
+
           args: --release --out dist --find-interpreter
           sccache: 'true'
           manylinux: auto
       - name: Upload wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: wheels-linux-${{ matrix.target }}
           path: dist
 
   windows:
@@ -92,25 +92,25 @@ jobs:
       matrix:
         target: [x64]
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
-          
+
           architecture: ${{ matrix.target }}
-          
+
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
-          
+
           target: ${{ matrix.target }}
-          
+
           args: --release --out dist --find-interpreter
           sccache: 'true'
       - name: Upload wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: wheels-windows-${{ matrix.target }}
           path: dist
 
   macos:
@@ -119,37 +119,37 @@ jobs:
       matrix:
         target: [x86_64, aarch64]
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
-          
+
           target: ${{ matrix.target }}
-          
+
           args: --release --out dist --find-interpreter
           sccache: 'true'
       - name: Upload wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: wheels-macos-${{ matrix.target }}
           path: dist
 
   sdist:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build sdist
         uses: PyO3/maturin-action@v1
         with:
           command: sdist
           args: --out dist
       - name: Upload sdist
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: wheels-sdist
           path: dist
 
   release:
@@ -163,9 +163,10 @@ jobs:
       contents: read  # Required for downloading built artifacts
     steps:
       # Step 1: Download Artifacts
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
-          name: wheels
+          pattern: wheels-*
+          merge-multiple: true
 
       # Step 2: Publish to PyPI
       - name: Publish to PyPI

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,9 @@ name = "polars_grouper"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.22.3", features = ["extension-module", "abi3-py38"] }
-pyo3-polars = { version = "0.17.0", features = ["derive", "dtype-struct"] }
+pyo3 = { version = "0.27", features = ["extension-module", "abi3-py310"] }
+pyo3-polars = { version = "0.26.0", features = ["derive", "dtype-struct"] }
 serde = { version = "1", features = ["derive"] }
-polars = { version = "0.43.1", features=["dtype-struct"], default-features = false }
+polars = { version = "0.53.0", features=["dtype-struct"], default-features = false }
 smallvec = "1.13.2"
 rustc-hash = "2.0.0"

--- a/polars_grouper/__init__.py
+++ b/polars_grouper/__init__.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeVar
 
 import polars as pl
 from polars.plugins import register_plugin_function
 from polars_grouper._internal import __version__ as __version__
-from typing import TypeVar
 
 DF = TypeVar("DF", pl.DataFrame, pl.LazyFrame)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin>=1.0,<2.0", "polars>=1.3.0"]
+requires = ["maturin>=1.0,<2.0", "polars>=1.39.0"]
 build-backend = "maturin"
 
 [project]
@@ -9,7 +9,7 @@ description = "High-performance graph analysis and pattern mining extension for 
 authors = [
     { name = "Edward Vaneechoud", email = "evaneechoud@gmail.com" }
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 license = "MIT"
 readme = "README.md"
 keywords = ["polars", "graph", "network", "clustering", "data-science"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "polars-grouper"
-version = "0.3.0"
+version = "0.4.0"
 description = "High-performance graph analysis and pattern mining extension for Polars"
 authors = [
     { name = "Edward Vaneechoud", email = "evaneechoud@gmail.com" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,9 +65,11 @@ module = "tests.*"
 disable_error_code = ["arg-type", "attr-defined"]  # Disable specific errors for tests
 
 [tool.ruff]
-select = ["E", "F", "B", "Q", "D"]
-ignore = ["D100", "D104", "D205", "D212"]
 line-length = 120
+
+[tool.ruff.lint]
+select = ["E", "F", "B", "Q", "D"]
+ignore = ["D100", "D104", "D205", "D211", "D212"]
 
 
 [tool.pytest.ini_options]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-polars~=1.0
+polars~=1.39
 maturin~=1.7
 ruff~=0.7.0
 pytest~=8.3.3

--- a/src/association_rule_graph_mining.rs
+++ b/src/association_rule_graph_mining.rs
@@ -275,7 +275,7 @@ fn graph_association_rules(
         }
     }
 
-    let fields = vec![
+    let fields = [
         Series::new("item".into(), items),
         Series::new("support".into(), supports),
         Series::new("lift_score".into(), lift_scores),

--- a/src/association_rule_graph_mining.rs
+++ b/src/association_rule_graph_mining.rs
@@ -284,5 +284,6 @@ fn graph_association_rules(
         Series::new("confidence_scores".into(), confidence_scores),
     ];
 
-    StructChunked::from_series("association_rules".into(), &fields).map(|ca| ca.into_series())
+    let length = fields.first().map(|s| s.len()).unwrap_or(0);
+    StructChunked::from_series(PlSmallStr::from("association_rules"), length, fields.iter()).map(|ca| ca.into_series())
 }

--- a/src/graph_betweenness_centrality.rs
+++ b/src/graph_betweenness_centrality.rs
@@ -189,7 +189,7 @@ fn graph_betweenness_centrality(
         })
         .unzip();
 
-    let fields = vec![
+    let fields = [
         Series::new(PlSmallStr::from("node"), nodes),
         Series::new(PlSmallStr::from("centrality"), centrality_values),
     ];

--- a/src/graph_betweenness_centrality.rs
+++ b/src/graph_betweenness_centrality.rs
@@ -194,6 +194,7 @@ fn graph_betweenness_centrality(
         Series::new(PlSmallStr::from("centrality"), centrality_values),
     ];
 
-    StructChunked::from_series(PlSmallStr::from("betweenness_centrality"), &fields)
+    let length = fields.first().map(|s| s.len()).unwrap_or(0);
+    StructChunked::from_series(PlSmallStr::from("betweenness_centrality"), length, fields.iter())
         .map(|ca| ca.into_series())
 }

--- a/src/shortest_path.rs
+++ b/src/shortest_path.rs
@@ -196,7 +196,7 @@ fn graph_find_shortest_path(inputs: &[Series], kwargs: ShortestPathKwargs) -> Po
         }
     }
 
-    let fields = vec![
+    let fields = [
         Series::new(PlSmallStr::from("from"), from_nodes),
         Series::new(PlSmallStr::from("to"), to_nodes),
         Series::new(PlSmallStr::from("distance"), distances),

--- a/src/shortest_path.rs
+++ b/src/shortest_path.rs
@@ -202,5 +202,6 @@ fn graph_find_shortest_path(inputs: &[Series], kwargs: ShortestPathKwargs) -> Po
         Series::new(PlSmallStr::from("distance"), distances),
     ];
 
-    StructChunked::from_series(PlSmallStr::from("shortest_paths"), &fields).map(|ca| ca.into_series())
+    let length = fields.first().map(|s| s.len()).unwrap_or(0);
+    StructChunked::from_series(PlSmallStr::from("shortest_paths"), length, fields.iter()).map(|ca| ca.into_series())
 }

--- a/tests/test_graph_solver.py
+++ b/tests/test_graph_solver.py
@@ -443,6 +443,5 @@ def test_calculate_path_empty_graph() -> None:
     ...
 
 
-
 if __name__ == "__main__":
     pytest.main()

--- a/tests/test_graph_solver.py
+++ b/tests/test_graph_solver.py
@@ -317,7 +317,7 @@ def test_weighted_vs_unweighted() -> None:
     ).unnest("rules")
 
     # Support values should differ between weighted and unweighted
-    assert not all(w == u for w, u in zip(weighted["support"], unweighted["support"]))
+    assert not all(w == u for w, u in zip(weighted["support"], unweighted["support"], strict=True))
 
 
 def test_max_itemset_size() -> None:


### PR DESCRIPTION
## Summary
This PR updates the codebase to be compatible with Polars 0.53.0 and newer versions of pyo3 and pyo3-polars. The main changes involve adapting to breaking API changes in the `StructChunked::from_series` method signature.

## Key Changes
- **Updated dependencies:**
  - pyo3: 0.22.3 → 0.27
  - pyo3-polars: 0.17.0 → 0.26.0
  - polars: 0.43.1 → 0.53.0
  - Python requirement: >=3.8 → >=3.10

- **API migration for StructChunked::from_series:**
  - Updated `association_rule_graph_mining.rs`: Changed from `StructChunked::from_series(name, &fields)` to `StructChunked::from_series(name, length, fields.iter())`
  - Updated `graph_betweenness_centrality.rs`: Applied same API change pattern
  - Updated `shortest_path.rs`: Applied same API change pattern

## Implementation Details
The `StructChunked::from_series` method signature changed to require an explicit length parameter and an iterator over fields instead of a slice reference. Each call now:
1. Extracts the length from the first field (or defaults to 0 if empty)
2. Passes the length as an explicit parameter
3. Uses `fields.iter()` instead of `&fields` for the fields parameter

This change aligns with Polars' API evolution toward more explicit and flexible struct construction.

https://claude.ai/code/session_01HyKzkuPhQFU8AsPfn3PcS6