### PR TITLE
Fix calculate_shortest_path to prevent duplicate directed pairs and improve weight handling

### DIFF
--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -65,7 +65,7 @@ jobs:
   # release would otherwise only surface downstream at plugin *call* time.
   # This job tests against the newest Polars on PyPI and is allowed to fail.
   # When it goes red, tighten the upper bound in [project].dependencies in
-  # pyproject.toml (currently `polars>=1.3.0,<2.0.0`) and cut a release.
+  # pyproject.toml (currently `polars>=1.39.0,<2.0.0`) and cut a release.
   latest_polars_test:
     name: Test against latest Polars (informational)
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+All notable changes to `polars-grouper` are documented here.
+
+## 0.5.1
+
+### Fixed
+
+- **`calculate_shortest_path(..., directed=True)` returned every reachable pair twice.**
+  Results were duplicated by an exact factor of 2 for all directed graphs, with no error
+  raised. Anything aggregating a directed result — a sum, a count, a mean weighted by row
+  count — was wrong by that factor, so **directed results computed with 0.5.0 or earlier
+  should be recomputed**. Undirected results were unaffected. The cause was the
+  result-collection loop: the inner loop already ran over every *ordered* pair, and a
+  second reverse-direction pass then emitted each pair's mirror image again.
+- `calculate_shortest_path` now broadcasts a length-1 weights argument across every edge,
+  so `pl.lit(1.0)` means "all edges weigh the same". Previously the scalar was zipped
+  against the node columns, truncating the graph to a single edge and silently returning
+  a result computed from it. Any other length mismatch now raises a `ShapeMismatch`
+  naming the offending argument and the expected length, instead of truncating.
+- `calculate_shortest_path` no longer panics on an empty edge list (an unsigned subtraction
+  overflowed when reserving result capacity for a zero-node graph).
+
+### Changed
+
+- `calculate_shortest_path` now runs one single-source Dijkstra per node instead of one
+  per node *pair*, reducing the number of traversals from O(V²) to O(V). Output row
+  ordering is unchanged.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "polars-grouper" # Updated to match the new name
 # Keep in sync with [project].version in pyproject.toml -- this is what
 # `polars_grouper.__version__` reports, via env!("CARGO_PKG_VERSION").
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 
 [lib]

--- a/polars_grouper/__init__.py
+++ b/polars_grouper/__init__.py
@@ -91,6 +91,8 @@ def calculate_shortest_path(
         Expression representing the destination nodes of the edges.
     weights : IntoExpr
         Expression representing the edge weights. Must be non-negative values.
+        A single scalar (for example ``pl.lit(1.0)``) is broadcast to every edge;
+        any other length that does not match the edge count raises an error.
     directed : bool, default False
         If True, treats the graph as directed. If False, treats edges as bidirectional.
 
@@ -139,6 +141,9 @@ def calculate_shortest_path(
     Notes
     -----
     - Returns only existing paths (unreachable pairs are excluded)
+    - Each pair is returned exactly once: directed results contain both A→B and B→A,
+      undirected results contain a single row per pair with the lexicographically
+      smaller node in "from"
     - Weights must be non-negative
     - For undirected graphs, paths A→B and B→A will have the same distance
     - Memory usage scales with O(V²) where V is the number of vertices

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,13 +4,15 @@ build-backend = "maturin"
 
 [project]
 name = "polars-grouper"
-version = "0.5.0"
+version = "0.5.1"
 description = "High-performance graph analysis and pattern mining extension for Polars"
 authors = [
     { name = "Edward Vaneechoud", email = "evaneechoud@gmail.com" }
 ]
 requires-python = ">=3.10"
-dependencies = ["polars>=1.3.0,<2.0.0"]
+dependencies = [
+    "polars>=1.39.0,<2.0.0",
+]
 license = "MIT"
 readme = "README.md"
 keywords = ["polars", "graph", "network", "clustering", "data-science"]

--- a/src/association_rule_graph_mining.rs
+++ b/src/association_rule_graph_mining.rs
@@ -285,5 +285,6 @@ fn graph_association_rules(
     ];
 
     let length = fields.first().map(|s| s.len()).unwrap_or(0);
-    StructChunked::from_series(PlSmallStr::from("association_rules"), length, fields.iter()).map(|ca| ca.into_series())
+    StructChunked::from_series(PlSmallStr::from("association_rules"), length, fields.iter())
+        .map(|ca| ca.into_series())
 }

--- a/src/graph_betweenness_centrality.rs
+++ b/src/graph_betweenness_centrality.rs
@@ -195,6 +195,10 @@ fn graph_betweenness_centrality(
     ];
 
     let length = fields.first().map(|s| s.len()).unwrap_or(0);
-    StructChunked::from_series(PlSmallStr::from("betweenness_centrality"), length, fields.iter())
-        .map(|ca| ca.into_series())
+    StructChunked::from_series(
+        PlSmallStr::from("betweenness_centrality"),
+        length,
+        fields.iter(),
+    )
+    .map(|ca| ca.into_series())
 }

--- a/src/graph_utils.rs
+++ b/src/graph_utils.rs
@@ -98,3 +98,36 @@ where
 
     Ok((node_to_id, id_counter, edges))
 }
+
+/// Align an input column with the number of edges in the graph.
+///
+/// A length-1 column is treated as a scalar and repeated, so `pl.lit(1.0)` means
+/// "every edge weighs the same". Any other length mismatch is an error: zipping
+/// columns of unequal length silently truncates to the shortest one and builds a
+/// graph that is missing most of its edges.
+pub fn broadcast_to_len(series: &Series, len: usize, role: &str) -> PolarsResult<Series> {
+    if series.len() == len {
+        Ok(series.clone())
+    } else if series.len() == 1 {
+        Ok(series.new_from_index(0, len))
+    } else {
+        polars_bail!(
+            ShapeMismatch:
+            "`{}` has length {}, expected {} (one value per edge) or 1 (a scalar broadcast to every edge)",
+            role, series.len(), len
+        )
+    }
+}
+
+/// The number of edges implied by the node columns of a graph.
+///
+/// Columns of length 1 are scalars and do not constrain the edge count; if every
+/// column is a scalar the graph has a single edge.
+pub fn edge_count(inputs: &[Series]) -> usize {
+    inputs
+        .iter()
+        .map(|s| s.len())
+        .filter(|&l| l != 1)
+        .max()
+        .unwrap_or(1)
+}

--- a/src/shortest_path.rs
+++ b/src/shortest_path.rs
@@ -1,4 +1,6 @@
-use crate::graph_utils::{to_float64_chunked, to_string_chunked, usize_to_t, AsUsize};
+use crate::graph_utils::{
+    broadcast_to_len, edge_count, to_float64_chunked, to_string_chunked, usize_to_t, AsUsize,
+};
 use polars::prelude::*;
 use pyo3_polars::derive::polars_expr;
 use serde::Deserialize;
@@ -75,11 +77,13 @@ where
     Ok((node_to_id, id_counter, edges))
 }
 
-fn shortest_path<T>(start_id: usize, target_id: usize, adj_list: &[Vec<(usize, i64)>]) -> f64
-where
-    T: TryFrom<usize> + Copy + PartialEq + AsUsize + Into<u64>,
-    <T as TryFrom<usize>>::Error: std::fmt::Debug,
-{
+/// Single-source Dijkstra.
+///
+/// Returns the cost of the cheapest path from `start_id` to every node, with
+/// `i64::MAX` marking nodes that are unreachable. Resolving every target in one
+/// traversal is what lets the caller emit exactly one row per (source, target)
+/// pair from a single loop.
+fn shortest_paths_from(start_id: usize, adj_list: &[Vec<(usize, i64)>]) -> Vec<i64> {
     let num_nodes = adj_list.len();
     let mut dist = vec![i64::MAX; num_nodes];
     dist[start_id] = 0;
@@ -91,10 +95,6 @@ where
     });
 
     while let Some(State { cost, position }) = heap.pop() {
-        if position == target_id {
-            return cost as f64 / 1000.0;
-        }
-
         if cost > dist[position] {
             continue;
         }
@@ -111,7 +111,7 @@ where
         }
     }
 
-    f64::INFINITY
+    dist
 }
 
 fn shortest_path_output(_: &[Field]) -> PolarsResult<Field> {
@@ -125,12 +125,13 @@ fn shortest_path_output(_: &[Field]) -> PolarsResult<Field> {
     ))
 }
 
-
 #[polars_expr(output_type_func=shortest_path_output)]
 fn graph_find_shortest_path(inputs: &[Series], kwargs: ShortestPathKwargs) -> PolarsResult<Series> {
-    let from = to_string_chunked(&inputs[0])?;
-    let to = to_string_chunked(&inputs[1])?;
-    let weights = to_float64_chunked(&inputs[2])?;
+    // `from`/`to` define the edges; a scalar weight is then stretched to match them.
+    let num_edges = edge_count(&inputs[..2]);
+    let from = to_string_chunked(&broadcast_to_len(&inputs[0], num_edges, "from")?)?;
+    let to = to_string_chunked(&broadcast_to_len(&inputs[1], num_edges, "to")?)?;
+    let weights = to_float64_chunked(&broadcast_to_len(&inputs[2], num_edges, "weights")?)?;
 
     type NodeId = u32;
 
@@ -145,10 +146,11 @@ fn graph_find_shortest_path(inputs: &[Series], kwargs: ShortestPathKwargs) -> Po
         }
     }
 
+    let ordered_pairs = num_nodes * num_nodes.saturating_sub(1);
     let estimated_pairs = if kwargs.directed {
-        num_nodes * (num_nodes - 1)
+        ordered_pairs
     } else {
-        (num_nodes * (num_nodes - 1)) / 2
+        ordered_pairs / 2
     };
 
     let mut from_nodes = Vec::with_capacity(estimated_pairs);
@@ -161,38 +163,21 @@ fn graph_find_shortest_path(inputs: &[Series], kwargs: ShortestPathKwargs) -> Po
         .collect();
     node_ids.sort_by(|a, b| a.0.cmp(b.0));
 
-    for i in 0..node_ids.len() {
-        for j in (if kwargs.directed { 0 } else { i + 1 })..node_ids.len() {
-            if i == j {
+    // A directed graph emits every ordered pair, so each source scans every target.
+    // An undirected pair is emitted once; since node_ids is sorted by name, starting
+    // at i + 1 also puts the lexicographically smaller node in `from`.
+    for (i, &(start_name, start_id)) in node_ids.iter().enumerate() {
+        let dist = shortest_paths_from(start_id, &adj_list);
+        let first_target = if kwargs.directed { 0 } else { i + 1 };
+
+        for (j, &(target_name, target_id)) in node_ids.iter().enumerate().skip(first_target) {
+            if i == j || dist[target_id] == i64::MAX {
                 continue;
             }
 
-            let (start_name, start_id) = node_ids[i];
-            let (target_name, target_id) = node_ids[j];
-
-            let distance = shortest_path::<NodeId>(start_id, target_id, &adj_list);
-
-            if distance != f64::INFINITY {
-                // For undirected graphs, always store lexicographically smaller node first
-                if !kwargs.directed && start_name > target_name {
-                    from_nodes.push(target_name.clone());
-                    to_nodes.push(start_name.clone());
-                } else {
-                    from_nodes.push(start_name.clone());
-                    to_nodes.push(target_name.clone());
-                }
-                distances.push(distance);
-            }
-
-            if kwargs.directed {
-                let reverse_distance = shortest_path::<NodeId>(target_id, start_id, &adj_list);
-
-                if reverse_distance != f64::INFINITY {
-                    from_nodes.push(target_name.clone());
-                    to_nodes.push(start_name.clone());
-                    distances.push(reverse_distance);
-                }
-            }
+            from_nodes.push(start_name.clone());
+            to_nodes.push(target_name.clone());
+            distances.push(dist[target_id] as f64 / 1000.0);
         }
     }
 
@@ -203,5 +188,6 @@ fn graph_find_shortest_path(inputs: &[Series], kwargs: ShortestPathKwargs) -> Po
     ];
 
     let length = fields.first().map(|s| s.len()).unwrap_or(0);
-    StructChunked::from_series(PlSmallStr::from("shortest_paths"), length, fields.iter()).map(|ca| ca.into_series())
+    StructChunked::from_series(PlSmallStr::from("shortest_paths"), length, fields.iter())
+        .map(|ca| ca.into_series())
 }

--- a/tests/test_graph_solver.py
+++ b/tests/test_graph_solver.py
@@ -393,25 +393,87 @@ def test_calculate_shortest_path() -> None:
         assert abs(actual_paths[(start, end)] - distance) < 0.1
 
 
+def _path_rows(df: pl.DataFrame, directed: bool) -> list[tuple[str, str, float]]:
+    """
+    Run calculate_shortest_path and return its rows as a sorted list of tuples.
+
+    Returning a list rather than a dict keeps duplicate ``(from, to)`` pairs visible;
+    collapsing the result into a dict is what let a 2x duplication bug go unnoticed.
+    """
+    result = df.select(
+        calculate_shortest_path(pl.col("from"), pl.col("to"), pl.col("weight"), directed=directed).alias("paths")
+    ).unnest("paths")
+    return sorted((row["from"], row["to"], round(row["distance"], 6)) for row in result.to_dicts())
+
+
 def test_directed_path() -> None:
     """
     Test the calculate_shortest_path function with directed edges.
     Verifies that path distances are asymmetric when the graph is directed,
-    and that the function correctly handles different path weights in each direction.
+    and asserts the exact row set so that a duplicated or missing pair fails.
     """
     df = pl.DataFrame({"from": ["A", "B", "B", "C"], "to": ["B", "C", "A", "A"], "weight": [1.0, 2.0, 3.0, 4.0]})
 
-    result = df.select(
-        calculate_shortest_path(pl.col("from"), pl.col("to"), pl.col("weight"), directed=True).alias("paths")
-    ).unnest("paths")
+    assert _path_rows(df, directed=True) == [
+        ("A", "B", 1.0),
+        ("A", "C", 3.0),
+        ("B", "A", 3.0),
+        ("B", "C", 2.0),
+        ("C", "A", 4.0),
+        ("C", "B", 5.0),
+    ]
 
-    # Verify asymmetric paths
-    paths_dict = {(row["from"], row["to"]): row["distance"] for row in result.to_dicts()}
 
-    # A → B should be 1.0
-    assert abs(paths_dict[("A", "B")] - 1.0) < 1e-6
-    # B → A should be 3.0 (direct path)
-    assert abs(paths_dict[("B", "A")] - 3.0) < 1e-6
+def test_directed_path_branching_dag_exact_rows() -> None:
+    """
+    Assert the exact row set of a branching DAG in both directed and undirected mode.
+
+    The graph is a -> b, a -> c, b -> d with no parallel edges, so every reachable pair
+    has exactly one row. Branching makes the two modes differ in row count as well as in
+    content: b and c are mutually unreachable when directed, adjacent when not.
+    """
+    df = pl.DataFrame({"from": ["a", "a", "b"], "to": ["b", "c", "d"], "weight": [1.0, 2.0, 3.0]})
+
+    assert _path_rows(df, directed=True) == [
+        ("a", "b", 1.0),
+        ("a", "c", 2.0),
+        ("a", "d", 4.0),
+        ("b", "d", 3.0),
+    ]
+
+    assert _path_rows(df, directed=False) == [
+        ("a", "b", 1.0),
+        ("a", "c", 2.0),
+        ("a", "d", 4.0),
+        ("b", "c", 3.0),
+        ("b", "d", 3.0),
+        ("c", "d", 6.0),
+    ]
+
+
+def test_directed_path_emits_each_pair_once() -> None:
+    """
+    Regression test: a directed result must contain each (from, to) pair exactly once.
+
+    Released 0.5.0 emitted every reachable directed pair twice, because the loop over
+    ordered pairs and a second reverse-direction pass both pushed the same row.
+    """
+    df = pl.DataFrame(
+        {
+            "from": ["bike", "bike", "frame", "wheel", "wheel", "hub"],
+            "to": ["frame", "wheel", "tube", "spoke", "hub", "bearing"],
+            "weight": [1.0] * 6,
+        }
+    )
+
+    rows = _path_rows(df, directed=True)
+    assert len(rows) == len({(start, end) for start, end, _ in rows})
+    assert len(rows) == 11
+
+    # The same 7-node graph is fully connected when undirected: all 7 * 6 / 2 pairs.
+    undirected_rows = _path_rows(df, directed=False)
+    assert len(undirected_rows) == len({(start, end) for start, end, _ in undirected_rows})
+    assert len(undirected_rows) == 21
 
 
 def test_cycle_path() -> None:
@@ -431,6 +493,67 @@ def test_cycle_path() -> None:
 
     # A → C should choose shorter path (A → B → C = 2.0) over direct path (3.0)
     assert abs(paths_dict[("A", "C")] - 2.0) < 1e-6
+    assert len(result) == len(paths_dict)
+
+
+def test_shortest_path_simple_cycle() -> None:
+    """
+    Test a strongly connected 3-cycle a -> b -> c -> a.
+
+    Verifies that the traversal terminates on a cyclic graph and that the directed result
+    holds every ordered pair exactly once, with the wrap-around distances.
+    """
+    df = pl.DataFrame({"from": ["a", "b", "c"], "to": ["b", "c", "a"], "weight": [1.0, 1.0, 1.0]})
+
+    assert _path_rows(df, directed=True) == [
+        ("a", "b", 1.0),
+        ("a", "c", 2.0),
+        ("b", "a", 2.0),
+        ("b", "c", 1.0),
+        ("c", "a", 1.0),
+        ("c", "b", 2.0),
+    ]
+
+    assert _path_rows(df, directed=False) == [
+        ("a", "b", 1.0),
+        ("a", "c", 1.0),
+        ("b", "c", 1.0),
+    ]
+
+
+def test_shortest_path_scalar_weight_is_broadcast() -> None:
+    """
+    Test that a length-1 weights argument is broadcast across every edge.
+
+    A scalar such as pl.lit(1.0) must behave like a column of that value repeated per
+    edge, rather than being zipped against the node columns and truncating the graph.
+    """
+    df = pl.DataFrame({"from": ["a", "a", "b"], "to": ["b", "c", "d"], "weight": [1.0, 1.0, 1.0]})
+
+    scalar_result = df.select(
+        calculate_shortest_path(pl.col("from"), pl.col("to"), pl.lit(1.0), directed=True).alias("paths")
+    ).unnest("paths")
+    scalar_rows = sorted((row["from"], row["to"], round(row["distance"], 6)) for row in scalar_result.to_dicts())
+
+    assert scalar_rows == _path_rows(df, directed=True)
+    assert scalar_rows == [("a", "b", 1.0), ("a", "c", 1.0), ("a", "d", 2.0), ("b", "d", 1.0)]
+
+
+def test_shortest_path_mismatched_weight_length_raises() -> None:
+    """
+    Test that a weights argument of the wrong length raises instead of truncating.
+
+    Any length other than the edge count or 1 is ambiguous, so it must be an error
+    rather than a silently shortened edge list.
+    """
+    df = pl.DataFrame({"from": ["a", "a", "b"], "to": ["b", "c", "d"], "weight": [1.0, 1.0, 1.0]})
+
+    with pytest.raises(pl.exceptions.ComputeError, match="expected 3"):
+        df.select(
+            calculate_shortest_path(pl.col("from"), pl.col("to"), pl.Series("w", [1.0, 2.0]), directed=True).alias(
+                "paths"
+            )
+        ).unnest("paths")
 
 
 def test_calculate_path_empty_graph() -> None:
@@ -439,8 +562,17 @@ def test_calculate_path_empty_graph() -> None:
     Verifies that the function handles the edge case of an empty input
     DataFrame gracefully and returns an empty result.
     """
-    # Implement test for when the graph is empty
-    ...
+    df = pl.DataFrame(
+        {"from": [], "to": [], "weight": []},
+        schema={"from": pl.String, "to": pl.String, "weight": pl.Float64},
+    )
+
+    for directed in (True, False):
+        result = df.select(
+            calculate_shortest_path(pl.col("from"), pl.col("to"), pl.col("weight"), directed=directed).alias("paths")
+        ).unnest("paths")
+        assert result.height == 0
+        assert result.columns == ["from", "to", "distance"]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request releases version 0.5.1 of `polars-grouper`, focusing on fixing critical bugs and improving the correctness and robustness of the `calculate_shortest_path` function. The main changes address a duplication bug in directed shortest path results, improve handling of edge weights, and add comprehensive tests to prevent regressions. There are also updates to dependencies and documentation.

### Bug fixes and correctness improvements

* Fixed a bug where `calculate_shortest_path(..., directed=True)` returned every reachable pair twice, causing all directed results to be duplicated by a factor of two. Now, each pair is returned exactly once. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R28) [[2]](diffhunk://#diff-355db724a40a210fa5e56d7493ff1d9cb2f3dc33ad9079b45f47d60396e9bb96L164-R180) [[3]](diffhunk://#diff-1477e7bdbf0fcc97119a801a9e301be5cd7700e4f27dbc00e4480b3c532481b5R396-R476)
* The weights argument to `calculate_shortest_path` is now broadcast if it is a scalar (length-1), ensuring correct edge weighting. Any other length mismatch raises a `ShapeMismatch` error instead of truncating the graph. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R28) [[2]](diffhunk://#diff-355db724a40a210fa5e56d7493ff1d9cb2f3dc33ad9079b45f47d60396e9bb96L128-R134) [[3]](diffhunk://#diff-de53c841bbd8cae856ff0be43668da63504f040b33567b4c493f7874360d10d9R101-R133) [[4]](diffhunk://#diff-9b64a75b761c2508b2a833545b49674fb8d9278806cd5b203ae7abf2072dc2feR94-R95)
* The function no longer panics on an empty edge list; it now handles empty graphs gracefully and returns an empty result. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R28) [[2]](diffhunk://#diff-1477e7bdbf0fcc97119a801a9e301be5cd7700e4f27dbc00e4480b3c532481b5L442-R575)

### Performance and implementation changes

* Changed the shortest path algorithm to run one single-source Dijkstra per node instead of one per node pair, reducing the number of traversals from O(V²) to O(V) and improving efficiency. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R28) [[2]](diffhunk://#diff-355db724a40a210fa5e56d7493ff1d9cb2f3dc33ad9079b45f47d60396e9bb96L78-R86) [[3]](diffhunk://#diff-355db724a40a210fa5e56d7493ff1d9cb2f3dc33ad9079b45f47d60396e9bb96L114-R114) [[4]](diffhunk://#diff-355db724a40a210fa5e56d7493ff1d9cb2f3dc33ad9079b45f47d60396e9bb96L164-R180)

### Testing and documentation

* Added comprehensive regression and edge case tests for shortest path calculation, including tests for duplication, scalar weight broadcasting, length mismatch errors, cycles, and empty graphs. [[1]](diffhunk://#diff-1477e7bdbf0fcc97119a801a9e301be5cd7700e4f27dbc00e4480b3c532481b5R396-R476) [[2]](diffhunk://#diff-1477e7bdbf0fcc97119a801a9e301be5cd7700e4f27dbc00e4480b3c532481b5R496-R556) [[3]](diffhunk://#diff-1477e7bdbf0fcc97119a801a9e301be5cd7700e4f27dbc00e4480b3c532481b5L442-R575)
* Improved documentation for `calculate_shortest_path`, clarifying behavior for weights broadcasting, pair emission, and result structure. [[1]](diffhunk://#diff-9b64a75b761c2508b2a833545b49674fb8d9278806cd5b203ae7abf2072dc2feR94-R95) [[2]](diffhunk://#diff-9b64a75b761c2508b2a833545b49674fb8d9278806cd5b203ae7abf2072dc2feR144-R146)

### Dependency and release updates

* Updated the Polars dependency to require at least version 1.39.0. [[1]](diffhunk://#diff-5bdab82401d84fafcce36d5d8c3d9ba4c3682afec172b137defae42bb5f27d43L68-R68) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R15)
* Bumped the package version to 0.5.1 in both `Cargo.toml` and `pyproject.toml`. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L5-R5) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R15)
* Added a detailed changelog for version 0.5.1.